### PR TITLE
Fixed sign

### DIFF
--- a/dev/dark-style.css
+++ b/dev/dark-style.css
@@ -175,12 +175,16 @@ a:hover{
 
 
 .sign{
-  padding: 6px 12px;
+  display: inline-block;
+  position: relative;
+  padding: 6px 20px;
   color:#F7DA03;
   background: #303030;
   border:3px solid white;
   text-transform: uppercase;
+  text-align: center;
 }
+
 .sign:before,
 .sign:after{
   content:"";
@@ -188,9 +192,16 @@ a:hover{
   width:3px;
   height: 40px;
   background: white;
-  position: relative;
-  top:  55px;
+  position: absolute;
+  bottom: -44px;
 }
+.sign:before{
+  left: 12px;
+}
+.sign:after{
+  right: 12px;
+}
+
 #next h2{
   margin-bottom: 80px;
 }


### PR DESCRIPTION
На маленьких вьюпортах если знак не влезал, то разрывался на две строки, а стоечки накладывались на текст:
![before](https://cloud.githubusercontent.com/assets/13944414/24300327/eb8fcb7e-10cd-11e7-887f-fc4f1bc6705e.png)

Теперь он выглядит вот так:
![after](https://cloud.githubusercontent.com/assets/13944414/24300328/ec74a37a-10cd-11e7-9cf3-3870962ee90a.png)


